### PR TITLE
corrected statusLine method

### DIFF
--- a/Sources/VaporCurassow.swift
+++ b/Sources/VaporCurassow.swift
@@ -72,8 +72,8 @@ extension Vapor.Request {
 
 // MARK: Response Bridge
 
-extension Vapor.Response.ContentType {
-    var statusLine: String {
+extension Vapor.Response.ContentType: CustomStringConvertible {
+    public var description: String {
         switch self {
         case .Json:
             return "application/json"
@@ -91,7 +91,7 @@ extension Vapor.Response.ContentType {
 
 extension Vapor.Response: Nest.ResponseType {
     public var statusLine: String {
-        return contentType.statusLine
+        return "\(self.status.code) \(self.status.reasonPhrase)"
     }
     
     public var headers: [Nest.Header] {


### PR DESCRIPTION
I used this repo in a toy project today and noticed that my browser was rendering the HTTP headers together with my page content as plain text. I realized this happened because the status line produced by the extension to `Vapor.Response` did not follow the HTTP specs. According to [RFC 2616][rfc], the status line should consist of:

```
<HTTP-Version> <Status-Code> <Reason-Phrase>
```

I removed the content-type information from `.statusLine`, replacing it with calls to `Vapor.Response.Status.code` and `.reasonPhrase`. Doing so caused my responses to render correctly (as HTML) in my browser.

For posterity, I kept the extension to `Vapor.Response.ContentType` but changed the method to `description` and added `CustomStringConvertible` conformance. It's obviously not used anywhere else, but I felt bad taking it out. :sweat_smile: 

Cheers!

[rfc]: https://tools.ietf.org/html/rfc2616#section-6.1